### PR TITLE
Small fixes

### DIFF
--- a/Chapter 10 - Practice Set/04_problem4.c
+++ b/Chapter 10 - Practice Set/04_problem4.c
@@ -23,10 +23,12 @@ int main()
     fprintf(ptr, "%s", ", ");
     fprintf(ptr, "%d", salary1);
     fprintf(ptr, "%c", '\n');
-     fprintf(ptr, "%s", name2);
+    fprintf(ptr, "%s", name2);
     fprintf(ptr, "%s", ", ");
     fprintf(ptr, "%d", salary2);
     fprintf(ptr, "%c", '\n');
+
+    fclose(ptr);
 
     return 0;
 }

--- a/Chapter 10/04_fgetc_fputc.c
+++ b/Chapter 10/04_fgetc_fputc.c
@@ -7,5 +7,8 @@ int main()
     // char c = fgetc(ptr); // used to read a character from file
     // printf("%c", c);
     fputc('c', ptr);
+
+    fclose(ptr); // Close the file to prevent resource leak
+    
     return 0;
 }

--- a/Chapter 11/01_dma.c
+++ b/Chapter 11/01_dma.c
@@ -6,9 +6,16 @@ int main(){
     int* ptr;
     scanf("%d", &n);
     ptr = (int*) malloc(n * sizeof(int));
-    // int arr[n]; // Not allowed in c
+    if (ptr == NULL) {
+        printf("Memory allocation failed\n");
+        return 1; // Exit program if memory allocation fails
+    }
+    // int arr[n]; // Not allowed in C
     ptr[0] = 3;
-    ptr [1]= 6;
+    ptr[1] = 6;
     printf("%d", ptr[0]);
+
+    free(ptr); // Free allocated memory
+
     return 0;
 }

--- a/Chapter 11/02_quick_quiz.c
+++ b/Chapter 11/02_quick_quiz.c
@@ -5,17 +5,24 @@ int main(){
     float n = 5;
     float* ptr; 
     ptr = (float*) malloc(n * sizeof(float)); 
+    if (ptr == NULL) {
+        printf("Memory allocation failed\n");
+        return 1; // Exit program if memory allocation fails
+    }
 
     ptr[0] = 3.345;
-    ptr [1]= 16.345; 
-    ptr [2]= 6.345; 
-    ptr [3]= 56.345; 
-    ptr [4]= 66.345; 
+    ptr[1] = 16.345; 
+    ptr[2] = 6.345; 
+    ptr[3] = 56.345; 
+    ptr[4] = 66.345; 
 
     printf("%.2f\n", ptr[0]);
     printf("%.2f\n", ptr[1]);
     printf("%.2f\n", ptr[2]);
     printf("%.2f\n", ptr[3]);
     printf("%.2f\n", ptr[4]); 
+
+    free(ptr); // Free allocated memory
+
     return 0;
 }

--- a/Chapter 11/03_quick_quiz.c
+++ b/Chapter 11/03_quick_quiz.c
@@ -6,8 +6,14 @@ int main(){
     int* ptr;
     scanf("%d", &n);
     ptr = (int*) calloc(n, sizeof(int));
+    if (ptr == NULL) {
+        printf("Memory allocation failed\n");
+        return 1; // Exit program if memory allocation fails
+    }
     // int arr[n]; // Not allowed in c
     ptr[0] = 3; 
     printf("%d", ptr[0]);
+
+    free(ptr); // Free allocated memory
     return 0;
 }

--- a/Chapter 11/05_realloc.c
+++ b/Chapter 11/05_realloc.c
@@ -5,10 +5,26 @@ int main(){
     int n = 5;
     int* ptr; 
     ptr = (int*) malloc(n * sizeof(int)); 
+    if (ptr == NULL) {
+        printf("Memory allocation failed\n");
+        return 1; // Exit program if memory allocation fails
+    }
+    
     ptr[0] = 3;  
-    printf("%d", ptr[0]);
+    printf("%d\n", ptr[0]);
 
-    ptr = (int*) realloc(ptr, 10 * sizeof(int)); 
-    printf("%d", ptr[0]);
+    int* temp = (int*) realloc(ptr, 10 * sizeof(int)); 
+    if (temp == NULL) {
+        printf("Memory reallocation failed\n");
+        free(ptr); // Free original memory block on failure
+        return 1; // Exit program if memory reallocation fails
+    }
+    
+    ptr = temp; // Assign realloc'd pointer back to ptr
+    printf("%d\n", ptr[0]);
+    
+    // Don't forget to free allocated memory when done using it
+    free(ptr);
+
     return 0;
 }

--- a/Chapter 2 - Practice Set/03_problem3.c
+++ b/Chapter 2 - Practice Set/03_problem3.c
@@ -3,6 +3,6 @@
 int main(){
     // int a = 2342354;
     int a = 3349895;
-    printf("The value of a%97 is %d", a%97);
+    printf("The value of a%%97 is %d", a%97);
     return 0;
 }

--- a/Chapter 4/09_for.c
+++ b/Chapter 4/09_for.c
@@ -2,8 +2,8 @@
 
 int main(){
     int n = 6;
-    for(int i =0;i<n;i++){
-        printf("The value of i is %d\n");
+    for(int i = 0; i < n; i++){
+        printf("The value of i is %d\n", i);
     }
     return 0;
 }

--- a/Chapter 6 - Practice Set/05_problem5.c
+++ b/Chapter 6 - Practice Set/05_problem5.c
@@ -1,17 +1,25 @@
 #include <stdio.h>
-
+#include <stdlib.h> // for malloc and free
 
 int* sum(int a, int b){
-    int s = a+b;
-    int* ptr = &s;
-    printf("The sum is %d\n", s);
+    int* ptr = (int*)malloc(sizeof(int)); // Allocate memory for an int
+    if (ptr == NULL) {
+        printf("Memory allocation failed\n");
+        exit(1); // Exit program if memory allocation fails
+    }
+    *ptr = a + b;
+    printf("The sum is %d\n", *ptr);
     return ptr;
 }
 
 float* average(int a, int b){
-    float avg =  (a+b)/2.0;
-    float * ptr = &avg;
-    printf("The average is %f\n", avg);
+    float* ptr = (float*)malloc(sizeof(float)); // Allocate memory for a float
+    if (ptr == NULL) {
+        printf("Memory allocation failed\n");
+        exit(1); // Exit program if memory allocation fails
+    }
+    *ptr = (a + b) / 2.0;
+    printf("The average is %f\n", *ptr);
     return ptr;
 }
 
@@ -21,10 +29,14 @@ int main(){
     int* ptr1;
     float* ptr2;
 
-    ptr1 = sum(x,y);
-    ptr2 = average(x,y);
+    ptr1 = sum(x, y);
+    ptr2 = average(x, y);
 
-    printf("The address of sum is %u and of average is %u", ptr1, ptr2 );
+    printf("The address of sum is %p and of average is %p\n", (void*)ptr1, (void*)ptr2);
+
+    // Free allocated memory
+    free(ptr1);
+    free(ptr2);
 
     return 0;
 }

--- a/Chapter 9 - Practice Set/09_problem9.c
+++ b/Chapter 9 - Practice Set/09_problem9.c
@@ -39,6 +39,9 @@ int compare(DT d1, DT d2)
     {
         return -1;
     }
+
+    // Default case, should not reach here if all cases above are covered
+    return 0;
 }
 
 int main()


### PR DESCRIPTION
**Description**

There were a few errors and I fixed them.

**Affected Files:**

1. `Chapter 2 - Practice Set/03_problem3.c`

**Error:**

There's an error due to the `%` symbol being interpreted as a format specifier in the `printf` function. The string `"The value of a%97 is %d"` is expecting two parameters, but only one is provided.

**Fix:**

Escape the `%` symbol by using `%%` to ensure it is treated as a literal percentage character instead of a format specifier.

**Corrected Code:**

```c
#include <stdio.h>

int main(){
    // int a = 2342354;
    int a = 3349895;
    printf("The value of a%%97 is %d", a%97);
    return 0;
}
```

**Short Description of the Fix:**

The `%` character in the string is escaped by using `%%`, so it is printed as a literal percentage sign, avoiding the incorrect interpretation of a format specifier in the `printf` function.

2. `Chapter 4/09_for.c`

**Error:**

Τhe `printf` function format string requires one parameter (an integer) to match the `%d` format specifier, but no argument is provided.

**Fix:**

Pass the loop variable `i` as an argument to `printf` to match the `%d` format specifier.

**Corrected Code:**

```c
#include <stdio.h>

int main(){
    int n = 6;
    for(int i = 0; i < n; i++){
        printf("The value of i is %d\n", i);
    }
    return 0;
}
```

**Short Description of the Fix:**

The loop variable `i` is added as an argument to the printf function to match the `%d` format specifier, ensuring the correct number of arguments are provided.

3. `Chapter 6 - Practice Set/05_problem5.c`

**Error:**

The error occurs because the functions `sum` and `average` are returning pointers to local variables (`s` and `avg` respectively), which are local to those functions. Once the functions return, those local variables go out of scope, and the pointers become invalid, leading to undefined behavior when accessed later in `main`.

**Fix:**

To fix this issue, you should allocate memory dynamically for `s` and `avg` inside `sum` and average using `malloc` or `calloc`. This ensures that the memory remains valid even after the function returns. Remember to free the allocated memory in `main` after you have finished using it to prevent memory leaks.

**Corrected code:**

```c
#include <stdio.h>
#include <stdlib.h> // for malloc and free

int* sum(int a, int b){
    int* ptr = (int*)malloc(sizeof(int)); // Allocate memory for an int
    if (ptr == NULL) {
        printf("Memory allocation failed\n");
        exit(1); // Exit program if memory allocation fails
    }
    *ptr = a + b;
    printf("The sum is %d\n", *ptr);
    return ptr;
}

float* average(int a, int b){
    float* ptr = (float*)malloc(sizeof(float)); // Allocate memory for a float
    if (ptr == NULL) {
        printf("Memory allocation failed\n");
        exit(1); // Exit program if memory allocation fails
    }
    *ptr = (a + b) / 2.0;
    printf("The average is %f\n", *ptr);
    return ptr;
}

int main(){
    int x = 4; 
    int y = 6;
    int* ptr1;
    float* ptr2;

    ptr1 = sum(x, y);
    ptr2 = average(x, y);

    printf("The address of sum is %p and of average is %p\n", (void*)ptr1, (void*)ptr2);

    // Free allocated memory
    free(ptr1);
    free(ptr2);

    return 0;
}
```

4. `Chapter 9 - Practice Set/09_problem9.c`

**Error:**

The error occurs because the function `compare` is declared to return an `int`, but there are code paths within the function where no `return` statement is provided. Specifically, if none of the conditions in the `compare` function's series of `if-else if` statements are true, the function does not return a value, which leads to undefined behavior.

**Fix:**

To fix this error, ensure that the `compare` function always returns an `int` value in all possible code paths. This can be achieved by adding a `return` statement at the end of the function, outside of any conditional statements, to handle the case where none of the conditions are met.

**Corrected code:**

```c
#include <stdio.h>

typedef struct Date
{
    int mm;
    int dd;
    int yyyy;
} DT;

int compare(DT d1, DT d2)
{
    // if d1 is in the future, return 1
    if ((d1.yyyy == d2.yyyy) && (d1.mm == d2.mm) && (d1.dd == d2.dd))
    {
        return 0;
    }

    if (d1.yyyy > d2.yyyy)
    {
        return 1;
    }
    else if (d1.yyyy < d2.yyyy)
    {
        return -1;
    }
    else if (d1.mm > d2.mm)
    {
        return 1;
    }
    else if (d1.mm < d2.mm)
    {
        return -1;
    }
    else if (d1.dd > d2.dd)
    {
        return 1;
    }
    else if (d1.dd < d2.dd)
    {
        return -1;
    }

    // Default case, should not reach here if all cases above are covered
    return 0;
}

int main()
{
    DT d1 = {12, 4, 2154};
    DT d2 = {12, 8, 2154};
    printf("%d", compare(d1, d2));
    return 0;
}
```

**Short Description of the Fix:**

The `compare` function is modified to ensure that it returns an `int` value in all possible execution paths. A `return 0;` statement is added at the end of the function to handle the default case where none of the earlier conditions are satisfied. This resolves the compiler error and ensures that the function behaves predictably in all scenarios.

5. `Chapter 10/04_fgetc_fputc.c`

**Error:**

The error occurs because the file `ptr` opened with `fopen` is not closed before the program terminates. This can lead to resource leakage where the file remains open in the operating system even after the program has finished executing.

**Fix:**

Close the file using `fclose(ptr)` after writing to it using `fputc`.

**Corrected code:**

```c
#include <stdio.h>

int main()
{
    FILE *ptr;
    ptr = fopen("harry.txt", "a");
    // char c = fgetc(ptr); // used to read a character from file
    // printf("%c", c);
    fputc('c', ptr);

    fclose(ptr); // Close the file to prevent resource leak
    
    return 0;
}
```

**Short Description of the Fix:**

The `fclose(ptr)` function is added to close the file after writing a character to it using `fputc`. This prevents resource leakage by properly releasing the file handle after its use.

6. `Chapter 10 - Practice Set/04_problem4.c`

**Error:**

The error is a resource leak, which means the file opened with `fopen` is not closed before the program terminates. This can lead to data not being properly written to the file and can also result in resource wastage.

**Fix:**

Close the file using fclose(ptr) after you are done writing to it.

**Corrected code:**

```c
#include <stdio.h>

int main()
{
    FILE *ptr;
    char name1[34], name2[34];
    int salary1, salary2;
    ptr = fopen("salary.txt", "w");

    printf("Enter the name of Employee \n");
    scanf("%s", name1);

    printf("Enter the salary of Employee \n");
    scanf("%d", &salary1);

    printf("Enter the name of Employee 2\n");
    scanf("%s", name2);

    printf("Enter the salary of Employee 2\n");
    scanf("%d", &salary2);

    fprintf(ptr, "%s", name1);
    fprintf(ptr, "%s", ", ");
    fprintf(ptr, "%d", salary1);
    fprintf(ptr, "%c", '\n');
    fprintf(ptr, "%s", name2);
    fprintf(ptr, "%s", ", ");
    fprintf(ptr, "%d", salary2);
    fprintf(ptr, "%c", '\n');

    // Close the file to avoid resource leak
    fclose(ptr);

    return 0;
}
```

**Short Description of the Fix:**

The fclose(ptr) function is added to close the file after writing the data. This ensures that the file is properly closed and the resources are released, preventing any resource leak.

7. `Chapter 11/01_dma.c`

**Error:**

The error occurs because memory allocated using `malloc` is not deallocated using `free` before the program terminates. This results in memory leak where the allocated memory remains allocated but inaccessible once the program finishes executing.

**Fix:**

To fix this issue, add a `free(ptr);` statement before the `return 0;` statement in `main` to deallocate the dynamically allocated memory pointed to by `ptr`.

**Corrected code:**

```c
#include <stdio.h>
#include <stdlib.h>

int main(){
    int n;
    int* ptr;
    scanf("%d", &n);
    ptr = (int*) malloc(n * sizeof(int));
    if (ptr == NULL) {
        printf("Memory allocation failed\n");
        return 1; // Exit program if memory allocation fails
    }
    // int arr[n]; // Not allowed in C
    ptr[0] = 3;
    ptr[1] = 6;
    printf("%d", ptr[0]);

    free(ptr); // Free allocated memory

    return 0;
}

```

**Short Description of the Fix:**

The code now includes `free(ptr);` to deallocate the memory allocated using `malloc` before the program terminates. This prevents memory leakage by ensuring that the dynamically allocated memory is released and made available for future use.

8. `Chapter 11/02_quick_quiz.c`

**Error:**

The error occurs because memory allocated using `malloc` is not deallocated using `free` before the program terminates. This results in memory leak where the allocated memory remains allocated but inaccessible once the program finishes executing.

**Fix:**

To fix this issue, add a `free(ptr);` statement before the `return 0;` statement in `main` to deallocate the dynamically allocated memory pointed to by `ptr`.

**Corrected code:**

```c
#include <stdio.h>
#include <stdlib.h>

int main(){
    float n = 5;
    float* ptr; 
    ptr = (float*) malloc(n * sizeof(float)); 
    if (ptr == NULL) {
        printf("Memory allocation failed\n");
        return 1; // Exit program if memory allocation fails
    }

    ptr[0] = 3.345;
    ptr[1] = 16.345; 
    ptr[2] = 6.345; 
    ptr[3] = 56.345; 
    ptr[4] = 66.345; 

    printf("%.2f\n", ptr[0]);
    printf("%.2f\n", ptr[1]);
    printf("%.2f\n", ptr[2]);
    printf("%.2f\n", ptr[3]);
    printf("%.2f\n", ptr[4]); 

    free(ptr); // Free allocated memory

    return 0;
}
```

**Short Description of the Fix:**

The code now includes `free(ptr);` to deallocate the memory allocated using `malloc` before the program terminates. This prevents memory leakage by ensuring that the dynamically allocated memory is released and made available for future use.

9. `Chapter 11/03_quick_quiz.c`

**Error:**

The error occurs because the memory allocated using `calloc` is not deallocated using `free` before the program terminates. This results in memory leak where the allocated memory remains allocated but inaccessible once the program finishes executing.

**Fix:**

To fix this issue, add a `free(ptr);` statement before the `return 0;` statement in `main` to deallocate the dynamically allocated memory pointed to by `ptr`.

**Corrected code:**

```c
#include <stdio.h>
#include <stdlib.h>

int main(){
    int n;
    int* ptr;
    scanf("%d", &n);
    ptr = (int*) calloc(n, sizeof(int));
    if (ptr == NULL) {
        printf("Memory allocation failed\n");
        return 1; // Exit program if memory allocation fails
    }
    // int arr[n]; // Not allowed in c
    ptr[0] = 3; 
    printf("%d", ptr[0]);

    free(ptr); // Free allocated memory
    return 0;
}
```

**Short Description of the Fix:**

The code now includes `free(ptr);` to deallocate the memory allocated using `calloc` before the program terminates. This prevents memory leakage by ensuring that the dynamically allocated memory is released and made available for future use.


10. `Chapter 11/05_realloc.c`

**Error:**

There are two main errors in the code snippet:

- **Memory Leak:** After reallocating memory using `realloc`, the original memory block allocated by `malloc` is no longer accessible, resulting in a memory leak.

- **Common realloc mistake:** If `realloc` fails (returns `NULL`), the original pointer `ptr` is overwritten with `NULL` without freeing the original memory block, leading to a memory leak.

**Fix:**

To fix these issues, you need to:

- Check if `realloc` returns `NULL` to handle allocation failure.
- Free the original memory block pointed to by `ptr` before assigning the result of `realloc` to `ptr`, to avoid memory leaks.

**Corrected code:**

```c
#include <stdio.h>
#include <stdlib.h>

int main(){
    int n = 5;
    int* ptr; 
    ptr = (int*) malloc(n * sizeof(int)); 
    if (ptr == NULL) {
        printf("Memory allocation failed\n");
        return 1; // Exit program if memory allocation fails
    }
    
    ptr[0] = 3;  
    printf("%d\n", ptr[0]);

    int* temp = (int*) realloc(ptr, 10 * sizeof(int)); 
    if (temp == NULL) {
        printf("Memory reallocation failed\n");
        free(ptr); // Free original memory block on failure
        return 1; // Exit program if memory reallocation fails
    }
    
    ptr = temp; // Assign realloc'd pointer back to ptr
    printf("%d\n", ptr[0]);
    
    // Don't forget to free allocated memory when done using it
    free(ptr);

    return 0;
}
```

**Short Description of the Fix:**

The code now checks the return value of `realloc` and ensures that the original memory block allocated by `malloc` is freed if `realloc` fails. This prevents memory leaks and ensures proper memory management throughout the program execution.

**Testing**

I made sure that all the programs above compile with no errors.

